### PR TITLE
fix(SS3): Changes to SS3

### DIFF
--- a/text/fishery-science-centers.qmd
+++ b/text/fishery-science-centers.qmd
@@ -95,7 +95,7 @@ Process Variations:
   
   - Scripts are specific to species
   
-  - Use of SS in the NW led to huge developments for packages that are tuned to its output such as r4ss and sa4ss
+  - Use of SS3 in the NW led to huge developments for packages that are tuned to its output such as r4ss and sa4ss
   
   - Process is not standardized for entire center (common among a lot of centers)
   
@@ -154,7 +154,7 @@ Gulf of Mexico:
 
   - Rmarkdown template used in process (private repository on GitHub)
   
-  - Work with SS report file and automate from there
+  - Work with SS3 report file and automate from there
   
   - Some parameters are hard coded and changed per species
   
@@ -208,7 +208,7 @@ Gulf of Mexico:
   
   - Large data sets/data takes a while to read in
   
-  - Cannot access others' SS output files dues to confidentiality (those outside of NOAA org)
+  - Cannot access others' SS3 output files dues to confidentiality (those outside of NOAA org)
   
   - Projections aren't standardized
   

--- a/text/stock-assessment-models.qmd
+++ b/text/stock-assessment-models.qmd
@@ -10,4 +10,4 @@
   
   - Include link/reference to papers/repositories at end of summary for reader to reference (also refer to FIT)
 
-  - WHAM, SS, BAM, ASAP, AMAK, Bespoke, FIMS, ect
+  - WHAM, SS3, BAM, ASAP, AMAK, Bespoke, FIMS, ect

--- a/text/tool-and-resources.qmd
+++ b/text/tool-and-resources.qmd
@@ -30,7 +30,7 @@
 
 ### safe Report Template {#sec-safe}
 
-### sa4ss - SS Report Template {#sec-sa4ss}
+### sa4ss - SS3 Report Template {#sec-sa4ss}
 
 ### MAFSC SAFE Reports Template {#sec-mafscsafe}
 


### PR DESCRIPTION
Stock Synthesis should be referred to as SS3 or Stock Synthesis in the text. All instances in *.qmd files that I found were changed from the two-letter abbreviation to "SS3".